### PR TITLE
Feature: use C extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,22 @@ pip install .
 
 Hopefully this eventually gets packaged and gets even easier.
 
-### C Library Installation
-By default the pip install will put a copy of the compiled `.so` files
-somewhere that the python code can find it if can't find them during install time.
+### C Library Compilation
 
-If you just want to install and use `minkasi` just from the library this should be fine.
+By default, the pip install will create a compiled C extension
+`_minkasi.<arch>.so` file so the Python code can load.
+
+By default, the compilation uses the system default compiler, and uses the
+tool `pkg-config` to locate the dependencies such as the `fftw3` lib. To
+specify alternative compiler or path to custom-built `fftw3`, use
+
+```
+export CC=/path/to/c/compiler
+export PKG_CONFIG_PATH=/path/to/fftw/pkgconfig:${PKG_CONFIG_PATH}
+pip install .
+```
+
+### For Development
 
 If you want to build the libraries on their own run `make all` from the root of the repo.
 This will put the compiled files in `~/.local/lib/`.
@@ -24,25 +35,29 @@ If you want to install them somewhere else `prefix=WHEREVER_YOU_WANT make -e all
 
 To make your system aware of these files use `ldconfig` if you have root.
 Otherwise add a line like:
+
 ```
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:~/.local/lib
-``` 
+```
+
 to your `.bashrc` or equivalent.
 
-### For Development
 If you are actively developing `minkasi` and want an live copy installed do:
+
 ```
 pip install -e .
 ```
 
 Note that this will not make changes to the C libraries automatically propagate.
-If you will be editing those files it is recommended to follow the instructions in the **C Library Installation** first and rerun the build process whenever you make a change. 
+If you will be editing those files it is recommended to follow the instructions in the **C Library Installation** first and rerun the build process whenever you make a change.
 
 ### Troubleshooting
 
 #### Missing Libraries
+
 If you are missing one of the libraries required for the C libraries the compilation will fail.
 This is most commonly due to a missing `fftw3` install in which case the compilation will produce an error message like:
+
 ```
 minkasi/mkfftw.c:4:10: fatal error: fftw3.h: No such file or directory
  #include <fftw3.h>
@@ -55,13 +70,16 @@ If you are on a cluster you may have to load the correct module to make it avail
 If you still are getting an error message like above make sure that the file its looking for is in a place where `gcc` can find it.
 To do this set `CPATH` to include the directory with the header file.
 Do this with:
+
 ```
 export CPATH=$CPATH:PATH_TO_DIR
 ```
 
 #### Linked Library Problems
+
 Sometime `gcc` can't find the linked libraries needed for compilation.
 In this case you will get an error message like:
+
 ```
 ld: cannot find -lfftw3f: No such file or directory
 ```
@@ -72,6 +90,7 @@ involve either installing or loading the correct modules.
 If you do have these libraries somewhere on disk but still get these error messaged you need to let `gcc` know where to look for them.
 To do this set `LIBRARY_PATH` to include the directories with the appropriate files (on Linux they will be `.so` files).
 Do this with:
+
 ```
 export LIBRARY_PATH=$LIBRARY_PATH:PATH_TO_DIR
 ```
@@ -79,17 +98,20 @@ export LIBRARY_PATH=$LIBRARY_PATH:PATH_TO_DIR
 ### Cluster Instructions
 
 #### Niagara
+
 ```
 module load gcc fftw
 ```
 
 #### NERSC
+
 ```
 module load craype-CRAY_CPU_TARGET
 module load cray-fftw
 export CPATH=$CPATH:$FFTW_INC
 export LIBRARY_PATH=$LIBRARY_PATH:$FFTW_DIR
 ```
+
 Where `CRAY_CPU_TARGET` is your target CPU (ie: `x86-milan)`.
 Run `module spider cray-fftw/VERSION` for more information.
 

--- a/minkasi/lib/_minkasi_init.py
+++ b/minkasi/lib/_minkasi_init.py
@@ -1,0 +1,12 @@
+import ctypes
+from pathlib import Path
+
+
+__all__ = ['libminkasi', 'libmkfftw']
+
+
+_libminkasi_path = next(iter(Path(__file__).parent.glob("_libminkasi.*.so")))
+libminkasi = ctypes.cdll.LoadLibrary(_libminkasi_path.as_posix())
+
+_libmkfftw_path = next(iter(Path(__file__).parent.glob("_libmkfftw.*.so")))
+libmkfftw = ctypes.cdll.LoadLibrary(_libmkfftw_path.as_posix())

--- a/minkasi/lib/minkasi.py
+++ b/minkasi/lib/minkasi.py
@@ -4,12 +4,7 @@ Python wrapper for the libminkasi C library.
 import ctypes
 import os
 
-try:
-    mylib = ctypes.cdll.LoadLibrary("libminkasi.so")
-except OSError:
-    mylib = ctypes.cdll.LoadLibrary(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "libminkasi.so")
-    )
+from ._minkasi_init import libminkasi as mylib
 
 # ------------------------------ tod2map functions --------------------------- #
 tod2map_simple_c = mylib.tod2map_simple

--- a/minkasi/lib/mkfftw.py
+++ b/minkasi/lib/mkfftw.py
@@ -1,12 +1,8 @@
 import ctypes
 import os
 
-try:
-    mylib = ctypes.cdll.LoadLibrary("libmkfftw.so")
-except OSError:
-    mylib = ctypes.cdll.LoadLibrary(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "libmkfftw.so")
-    )
+from ._minkasi_init import libmkfftw as mylib
+
 
 many_fft_r2c_1d_c = mylib.many_fft_r2c_1d
 many_fft_r2c_1d_c.argtypes = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "extension-helpers"]

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,82 @@
 from setuptools import Extension, setup
-import ctypes
 import subprocess
-import os
 
-try:
-    mylib=ctypes.cdll.LoadLibrary("libminkasi.so")
-except OSError:
-    os.environ["prefix"] = "minkasi/lib"
-    subprocess.check_call(["make", "-e", "libminkasi"])
-try:
-    mylib=ctypes.cdll.LoadLibrary("libmkfftw.so")
-except OSError:
-    os.environ["prefix"] = "minkasi/lib"
-    subprocess.check_call(["make", "-e", "libmkfftw"])
+from distutils.core import setup, Extension
+from collections import defaultdict
+from extension_helpers import get_compiler
+from extension_helpers import add_openmp_flags_if_available
+from pathlib import Path
+
+
+minkasi_dir = Path(__file__).parent.joinpath('minkasi/lib')
+
+
+def pkgconfig(package, kw):
+    flag_map = {'-I': 'include_dirs', '-L': 'library_dirs', '-l': 'libraries'}
+    cmd = 'pkg-config --cflags --libs {}'.format(package)
+    exitcode, output = subprocess.getstatusoutput(cmd)
+    if exitcode != 0:
+        raise ValueError(
+            f"Failed to run command `{cmd}`:\n\n{output}\n")
+    for token in output.strip().split():
+        kw.setdefault(flag_map.get(token[:2]), []).append(token[2:])
+    return kw
+
+
+def _add_common_ext_kwargs(cfg):
+    if get_compiler() in ('unix', 'mingw32'):
+        cfg['extra_compile_args'].extend([
+            '-pedantic',
+            '-Wno-newline-eof',
+            '-Wno-unused-const-variable',
+            ])
+    return cfg
+
+
+def minkasi_extension():
+    cfg = defaultdict(list)
+
+    files = [
+        'minkasi.c',
+        ]
+    cfg['sources'].extend(
+            minkasi_dir.joinpath(x).as_posix() for x in files)
+
+    # external dependencies
+    cfg['libraries'].append('m')
+    _add_common_ext_kwargs(cfg)
+
+    return Extension('minkasi.lib._libminkasi', **cfg)
+
+
+def mkfftw_extension():
+    cfg = defaultdict(list)
+
+    files = [
+        'mkfftw.c'
+        ]
+    cfg['sources'].extend(
+            minkasi_dir.joinpath(x).as_posix() for x in files)
+
+    # external dependencies
+    cfg['libraries'].append('m')
+
+    # add fftw3 config
+    cfg = pkgconfig('fftw3', cfg)
+    # this only added the non-threaded libs, and we also need the threaded
+    # ones
+    cfg['libraries'].extend(['fftw3_threads', 'fftw3f', 'fftw3f_threads'])
+    _add_common_ext_kwargs(cfg)
+    return Extension('minkasi.lib._libmkfftw', **cfg)
+
+
+def get_extensions():
+
+    extensions = [minkasi_extension(), mkfftw_extension()]
+    for ext in extensions:
+        add_openmp_flags_if_available(ext)
+    return extensions
+
 
 setup(
     name='minkasi',
@@ -25,5 +89,6 @@ setup(
 		'scipy'
     ],
     packages=['minkasi'],
-    package_data={"minkasi": ["lib/*.so"]},
+    # package_data={"minkasi": ["*.so"]},
+    ext_modules = get_extensions()
 )


### PR DESCRIPTION
Please take a look and see if there is anything breaking for your existing environments.

In particular, the code relies on the tool 'pkgconfig' to figure out the paths to the FFTW3 lib, which should be available on most modern systems and should work out of the box if FFTW3 is installed via the package manager.

For custom-built FFTW from source, the user needs to modify the `PKG_CONFIG_PATH` environment variable to include the path to the folder holding the `fftw3.pc` file in the build tree.

The C compiler can be specified via the `CC` environment variable.

fix #15 