### PR TITLE
fix: make WithDetWeights inherit from protocol

### DIFF
--- a/minkasi/mapmaking/noise.py
+++ b/minkasi/mapmaking/noise.py
@@ -94,7 +94,8 @@ class NoiseModelType(Protocol):
         return np.empty(0)
 
 
-class WithDetWeights(NoiseModelType):
+@runtime_checkable
+class WithDetWeights(NoiseModelType, Protocol):
     def get_det_weights(self) -> NDArray[np.floating]:
         return np.empty(0)
 


### PR DESCRIPTION
Fixes a bug pointed out by Joey Golec where noise models werent passing the check for having the `get_det_weights` function.