### PR TITLE
Remove AGBT18B_215_04 extend.

### DIFF
--- a/minkasi/tools/presets_by_source.py
+++ b/minkasi/tools/presets_by_source.py
@@ -282,7 +282,6 @@ def get_bad_tods(name, ndo=False, odo=False):
     bad_tod = bad_215_01
     bad_tod.extend(bad_215_02)
     bad_tod.extend(bad_215_03)
-    bad_tod.extend(bad_215_04)
     bad_tod.extend(bad_215_05)
     bad_tod.extend(bad_215_06)
     bad_tod.extend(bad_215_07)


### PR DESCRIPTION
After my last PR (PR #30), minkasi was throwing errors. I realized I forgot to remove the bad_tod.extend(bad_215_04) in presets_by_source.py when I commented out the AGBT18B_215_04. So now bad_tod.extend(bad_215_04) has been removed.