### PR TITLE
build: extend Makefile to add macOS support (#39)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,45 @@
-prefix = $(HOME)/.local/lib
+# ---------------------------------------------------------------------------
+# If a conda env is active, use it; otherwise fall back to system paths.
+# All variables can be overridden from the command line, e.g.:
+#   make all CC=gcc prefix=/your/lib/path
+# ---------------------------------------------------------------------------
+
+CONDA_PREFIX ?=
+
+ifdef CONDA_PREFIX
+  prefix  ?= $(CONDA_PREFIX)/lib
+  INCDIR  ?= $(CONDA_PREFIX)/include
+  LIBDIR  ?= $(CONDA_PREFIX)/lib
+  CC      ?= $(CONDA_PREFIX)/bin/clang
+else
+  prefix  ?= /usr/local/lib
+  INCDIR  ?= /usr/local/include
+  LIBDIR  ?= /usr/local/lib
+  CC      ?= clang
+endif
+
+CFLAGS   := -fopenmp -std=c99 -O3 -shared -fPIC
+INCLUDES := -I$(INCDIR)
+LDFLAGS  := -L$(LIBDIR)
+
+# ---------------------------------------------------------------------------
 
 build:
 	@mkdir -p $(prefix)
-	@if [[ :${LD_LIBRARY_PATH}: != *:${prefix}:* ]] ; then\
-	        echo "$(prefix) doesn't seem to be in LD_LIBRARY_PATH";\
-	        echo "You probably want it add it to your .bashrc or equivalent";\
-			echo "Add a line like export LD_LIBRARY_PATH=$(prefix)";\
-		fi
+	@if [[ :$${LD_LIBRARY_PATH}: != *:$(prefix):* ]]; then \
+	  echo "$(prefix) doesn't seem to be in LD_LIBRARY_PATH"; \
+	  echo "You probably want to add it to your .bashrc or equivalent"; \
+	  echo "Add a line like: export LD_LIBRARY_PATH=$(prefix)"; \
+	fi
 
 libminkasi:
-	gcc  -fopenmp -std=c99 -O3 -shared -fPIC -lm -lgomp -o $(prefix)/libminkasi.so minkasi/lib/minkasi.c
+	$(CC) $(INCLUDES) $(LDFLAGS) $(CFLAGS) -lm -lgomp \
+	  -o $(prefix)/libminkasi.so minkasi/lib/minkasi.c
 
 libmkfftw:
-	gcc  -fopenmp -std=c99 -O3 -shared -fPIC -lfftw3f_threads -lfftw3f -lfftw3_threads -lfftw3  -lm -lgomp -o $(prefix)/libmkfftw.so minkasi/lib/mkfftw.c
+	$(CC) $(INCLUDES) $(LDFLAGS) $(CFLAGS) \
+	  -lfftw3f_threads -lfftw3f -lfftw3_threads -lfftw3 -lm -lgomp \
+	  -o $(prefix)/libmkfftw.so minkasi/lib/mkfftw.c
 
 all: build libminkasi libmkfftw
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ export LIBRARY_PATH=$LIBRARY_PATH:PATH_TO_DIR
 module load gcc fftw
 ```
 
+### Installing on macOS
+The easiest way to install `minkasi` on macOS is to use [conda](https://docs.conda.io/) together with the conda compilers. First, install the compilers and `fftw` from conda-forge:
+
+```
+conda install -c conda-forge compilers fftw
+```
+
+Then install `minkasi` as usual:
+
+```
+pip install .
+```
+
 #### NERSC
 
 ```


### PR DESCRIPTION
PR created as suggested by @Sulla2012 in a comment to Issue #39.
It is meant for extending the Makefile to use the conda prefix if present. This is useful when running `minkasi` on, e.g., macOS.